### PR TITLE
Set of minor modifications

### DIFF
--- a/bin/soapy
+++ b/bin/soapy
@@ -5,6 +5,8 @@ either starts a command line or gui version of the simulation.
 '''
 import sys
 import os
+import matplotlib.pyplot as plt
+import numpy as np
 
 if sys.platform == "win32":
     # hack to stop the interpretter craching on ctrl-c events when scipy imported.

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -509,6 +509,8 @@ class SimConfig(ConfigObj):
         ``saveInstPsf``             Saves the instantenous science PSF.
         ``saveInstScieField``       Saves the instantaneous electric field at focal plane.
         ``saveSciRes``              Save Science residual phase
+        ``saveCalib``               Copy calibration (IM, Rec) to save directory
+                                    of simulation
         ======================      ===================
 
     """
@@ -534,6 +536,7 @@ class SimConfig(ConfigObj):
                             ("saveInstScieField", False),
                             ("saveWfe", False),
                             ("saveSciRes", False),
+                            ("saveCalib", False),
                             ("wfsMP", False),
                             ("verbosity", 2),
                             ("logfile", None),

--- a/soapy/gui.py
+++ b/soapy/gui.py
@@ -56,7 +56,7 @@ elif PYQT_VERSION == 4:
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 
 from matplotlib.figure import Figure
-
+import matplotlib.pyplot as pyplot
 from . import pyqtgraph
 
 # Change pyqtgraph colourmaps to more usual ones
@@ -226,7 +226,7 @@ class GUI(QtWidgets.QMainWindow):
 
         if PYQT_VERSION == 5:
             fname = fname[0]
-        
+
         fname = str(fname)
 
         if fname is not "":
@@ -751,7 +751,9 @@ class IPythonConsole:
                             "config" : config,
                             "simConfig" : sim.config.sim,
                             "telConfig" : sim.config.tel,
-                            "atmosConfig" : sim.config.atmos}
+                            "atmosConfig" : sim.config.atmos,
+                            "np" : numpy,
+                            "plt" : pyplot}
 
         for i in range(sim.config.sim.nGS):
             usefulObjects["wfs{}Config".format(i)] = sim.config.wfss[i]
@@ -851,4 +853,3 @@ if __name__ == "__main__":
 
 
     G = GUI(confFile, useOpenGL=args.gl)
-

--- a/soapy/reconstruction.py
+++ b/soapy/reconstruction.py
@@ -293,7 +293,7 @@ class Reconstructor(object):
                     wfs.config.eReadNoise = 0
 
                 iMat[i, n_wfs_measurments: n_wfs_measurments+wfs.n_measurements] = (
-                        -1 * wfs.frame(None, phase_correction=phase))# / dm.dmConfig.iMatValue
+                        -1 * wfs.frame(None, phase_correction=phase, iMatFrame=True))# / dm.dmConfig.iMatValue
                 n_wfs_measurments += wfs.n_measurements
 
                 # Turn noise back on again if it was turned off

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -83,6 +83,8 @@ import aotools
 #sim imports
 from . import atmosphere, logger, wfs, DM, reconstruction, SCI, confParse, interp
 
+import shutil
+
 #xrange now just "range" in python3.
 #Following code means fastest implementation used in 2 and 3
 try:
@@ -862,7 +864,11 @@ class Sim(object):
                                  header=self.config.sim.saveHeader,
                                  overwrite=True )
 
-
+            if self.config.sim.saveCalib:
+                shutil.copy(self.config.sim.simName + '/cMat.fits',
+                            self.path + "/cMat.fits")
+                shutil.copy(self.config.sim.simName + '/iMat.fits',
+                            self.path + "/iMat.fits")
 
     def makeSaveHeader(self):
         """

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -870,6 +870,23 @@ class Sim(object):
                 shutil.copy(self.config.sim.simName + '/iMat.fits',
                             self.path + "/iMat.fits")
 
+            # Creating cubes with the WfsFrames
+            if self.config.sim.saveWfsFrames:
+                for nwfs in xrange(self.config.sim.nGS):
+                    i = 0
+                    wfs_first = fits.getdata(
+                        self.path + "/wfsFPFrames/wfs-%d_frame-%d.fits" % (nwfs, i))
+                    wfs_cube = numpy.zeros((self.iters, wfs_first.shape[0],
+                                            wfs_first.shape[1]))
+                    wfs_cube[0, :, :] = wfs_first
+                    for i in range(1, self.iters):
+                        wfs_cube[i, :, :] = fits.getdata(
+                            self.path + "/wfsFPFrames/wfs-%d_frame-%d.fits" % (nwfs, i))
+
+                    fits.writeto(self.path + "/wfs_frames_%02d.fits" % (nwfs),
+                                 wfs_cube,
+                                 header=self.config.sim.saveHeader)
+
     def makeSaveHeader(self):
         """
         Forms a header which can be used to give a header to FITS files saved by the simulation.

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -885,7 +885,8 @@ class Sim(object):
 
                     fits.writeto(self.path + "/wfs_frames_%02d.fits" % (nwfs),
                                  wfs_cube,
-                                 header=self.config.sim.saveHeader)
+                                 header=self.config.sim.saveHeader,
+                                 overwrite = True)
 
     def makeSaveHeader(self):
         """

--- a/test/testSimulation.py
+++ b/test/testSimulation.py
@@ -6,6 +6,7 @@ import numpy
 from astropy.io import fits
 
 import os
+import shutil
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../conf/")
 
 soapy.logger.setLoggingLevel(3)
@@ -168,8 +169,56 @@ class TestSimpleSCAO(unittest.TestCase):
         #Check results are ok
         assert numpy.allclose(sim.longStrehl[0,-1], RESULTS["8x8_lgsuplink"], atol=0.2)
 
+
+    def testSaveData(self):
+        sim = soapy.Sim(os.path.join(CONFIG_PATH, "sh_8x8.yaml"))
+        sim.config.sim.simName = 'test_sh8x8'
+        sim.config.sim.logfile = False
+
+        sim.config.sim.saveSlopes = True
+        sim.config.sim.saveDmCommands = True
+        sim.config.sim.saveLgsPsf = True
+        sim.config.sim.saveWfe = True
+        sim.config.sim.saveStrehl = True
+        sim.config.sim.saveSciPsf = True
+        sim.config.sim.saveInstPsf = True
+        sim.config.sim.saveCalib = True
+        sim.config.sim.saveWfsFrames = True
+
+        sim.config.sim.saveSciRes = False
+        sim.config.sim.saveInstScieField = False
+
+        sim.config.sim.nIters = 2
+        wdir = os.path.dirname(os.path.abspath(__file__)) + '/'
+
+        sim.aoinit()
+        sim.makeIMat()
+        sim.aoloop()
+
+        try:
+            assert os.path.isfile(wdir + sim.path + '/slopes.fits') &\
+                os.path.isfile(wdir + sim.path + '/dmCommands.fits') &\
+                os.path.isfile(wdir + sim.path + '/lgsPsf.fits') &\
+                os.path.isfile(wdir + sim.path + '/WFE.fits') &\
+                os.path.isfile(wdir + sim.path + '/instStrehl.fits') &\
+                os.path.isfile(wdir + sim.path + '/longStrehl.fits') &\
+                os.path.isfile(wdir + sim.path + '/sciPsf_00.fits') &\
+                os.path.isfile(wdir + sim.path + '/sciPsfInst_00.fits') &\
+                os.path.isfile(wdir + sim.path + '/iMat.fits') &\
+                os.path.isfile(wdir + sim.path + '/cMat.fits') &\
+                os.path.isfile(wdir + sim.path + '/wfsFPFrames/wfs-0_frame-0.fits')
+                # os.path.isfile(wdir + sim.path + '/sciResidual_00.fits') &\
+                # os.path.isfile(wdir + sim.path + '/scieFieldInst_00_real.fits') &\
+                # os.path.isfile(wdir + sim.path + '/scieFieldInst_00_imag.fits') &\
+        except:
+            raise
+        finally:
+            dd = os.path.dirname(sim.path)
+            shutil.rmtree(wdir + dd)
+
+
 def testMaskLoad():
-    
+
     sim = soapy.Sim(os.path.join(CONFIG_PATH, "sh_8x8.yaml"))
     sim.config.sim.simName = None
     sim.config.sim.logfile = None

--- a/test/testSimulation.py
+++ b/test/testSimulation.py
@@ -189,10 +189,9 @@ class TestSimpleSCAO(unittest.TestCase):
         sim.config.sim.saveInstScieField = False
 
         sim.config.sim.nIters = 2
-        wdir = os.path.dirname(os.path.abspath(__file__)) + '/'
-
+        wdir ='./'
         sim.aoinit()
-        sim.makeIMat()
+        sim.makeIMat(forceNew=True)
         sim.aoloop()
 
         try:


### PR DESCRIPTION
- during interaction matrix acquisition, set 'iMatFrame=True' in the wfs frame acquisition. This disables unwanted effects (already implemented), notably set removeTT=False.
- numpy and pyplot standard aliases ('np' and 'plt') in interactive console and gui
- optionally save calibration files (IM, Rec) in simulation directory (could be consider as default?)
- if saving all WFS frames, also save them in a cube (in addition to single files). This feature is most likely debatable. I found it convenient but it saves twice the same data.


