### PR TITLE
Sci residual bugfix

### DIFF
--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -127,6 +127,9 @@ class PSF(object):
         and uses an FFT to transform to the focal plane.
         '''
 
+        # Store the residual phase for later analysis and plotting
+        self.residual = self.los.residual.copy() * self.mask
+
         numbalib.bilinear_interp(
                 self.los.phase, self.interp_coords, self.interp_coords, self.interp_phase,
                 self.thread_pool, bounds_check=False)

--- a/soapy/__init__.py
+++ b/soapy/__init__.py
@@ -25,7 +25,6 @@ if sys.platform == "win32":
     # described in more detail here:
     # http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
 
-    import imp
     import ctypes
     import _thread as thread
     import win32api

--- a/soapy/lineofsight.py
+++ b/soapy/lineofsight.py
@@ -239,7 +239,7 @@ class LineOfSight(object):
         """
         self.phase = numpy.zeros([self.nx_out_pixels] * 2, dtype=DTYPE)
         self.EField = numpy.ones([self.nx_out_pixels] * 2, dtype=CDTYPE)
-
+        self.residual = numpy.zeros([self.nx_out_pixels] * 2, dtype=DTYPE)
 
 ######################################################
 

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -758,12 +758,7 @@ class Sim(object):
                 self.instStrehl[sci,i] = self.sciCams[sci].instStrehl
                 self.longStrehl[sci,i] = self.sciCams[sci].longExpStrehl
 
-                # # Record WFE residual
-                # res = self.sciCams[sci].los.residual
-                # # Remove piston first
-                # res -= res.sum()/self.mask.sum()
-                # res *= self.mask
-                # self.WFE[sci,i] =  numpy.sqrt(numpy.mean(numpy.square(res)))
+                # Record WFE residual
                 self.WFE[sci, i] = self.sciCams[sci].calc_wavefronterror()
 
             if self.config.sim.saveSciRes:
@@ -1019,7 +1014,7 @@ class Sim(object):
                         instSciImg[i] = None
 
                     try:
-                        residual[i] = self.sciCams[i].los.residual.copy()*self.mask
+                        residual[i] = self.sciCams[i].residual
                     except AttributeError:
                         residual[i] = None
 


### PR DESCRIPTION
calculate the residual science phase in the science object at the `pupil_size` scale for plotting and saving 
(fixes bug #85 )