### PR TITLE
Better handling of bandwidth errors

### DIFF
--- a/soapy/gui.py
+++ b/soapy/gui.py
@@ -742,7 +742,7 @@ class IPythonConsole:
         self.kernel_manager.start_kernel()
         self.kernel = self.kernel_manager.kernel
 
-        self.kernel.shell.write("Welcome to AO Sim!")
+        self.kernel.shell.write("Welcome to AO Sim!\n")
 
         config = sim.config
         #Pass some useful objects to the user

--- a/soapy/logger.py
+++ b/soapy/logger.py
@@ -68,7 +68,7 @@ def setStatusFunc(func):
 def statusMessage(i, maxIter, message):
 	if not STATUS_FUNC:
 		sys.stdout.flush()
-		sys.stdout.write(COLOURS[4]+"\r{0} of {1}: {2}".format(i,maxIter, message)+COLOUR_RESET)
+		sys.stdout.write(COLOURS[4]+"\r{0} of {1}: {2}".format(i+1,maxIter, message)+COLOUR_RESET)
 
 	else:
 		STATUS_FUNC(message, i, maxIter)

--- a/soapy/reconstruction.py
+++ b/soapy/reconstruction.py
@@ -130,8 +130,7 @@ class Reconstructor(object):
 
         filename = self.sim_config.simName+"/cMat.fits"
 
-        logger.statusMessage(
-                    1,  1, "Load Command Matrix")
+        logger.info("Load Command Matrix")
 
         cMatHDU = fits.open(filename)[0]
         cMatHDU.verify("fix")
@@ -304,7 +303,7 @@ class Reconstructor(object):
             if callback != None:
                 callback()
 
-            logger.statusMessage(i+1, dm.n_acts,
+            logger.statusMessage(i, dm.n_acts,
                                  "Generating {} Actuator DM iMat".format(dm.n_acts))
 
         logger.info("Checking for redundant actuators...")

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -369,15 +369,13 @@ class Sim(object):
         s = 0
         for nwfs in wfsList:
             #check if due to read out WFS
-            if loopIter:
-                read=False
-                if (int(float(self.config.sim.loopTime*(loopIter+1))
-                        /self.config.wfss[nwfs].exposureTime)
-                                        != self.wfsFrameNo[nwfs]):
-                    self.wfsFrameNo[nwfs]+=1
-                    read=True
+            if (int(float(self.config.sim.loopTime*(loopIter+1))
+                    /self.config.wfss[nwfs].exposureTime)
+                                    != self.wfsFrameNo[nwfs]):
+                self.wfsFrameNo[nwfs]+=1
+                read=True
             else:
-                read = True
+                read=False
 
             slopes[s:s+self.wfss[nwfs].n_measurements] = \
                     self.wfss[nwfs].frame(self.scrns, dmShape, read=read)

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -371,7 +371,7 @@ class Sim(object):
             #check if due to read out WFS
             if loopIter:
                 read=False
-                if (int(float(self.config.sim.loopTime*loopIter)
+                if (int(float(self.config.sim.loopTime*(loopIter+1))
                         /self.config.wfss[nwfs].exposureTime)
                                         != self.wfsFrameNo[nwfs]):
                     self.wfsFrameNo[nwfs]+=1
@@ -425,7 +425,7 @@ class Sim(object):
             # check if due to read out WFS
             if loopIter:
                 read=False
-                if (int(float(self.config.sim.loopTime*loopIter)
+                if (int(float(self.config.sim.loopTime*(loopIter+1))
                         /self.config.wfss[nwfs].exposureTime)
                                         != self.wfsFrameNo[nwfs]):
                     self.wfsFrameNo[nwfs]+=1

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -129,9 +129,9 @@ class Sim(object):
         if configFile:
             self.configFile = configFile
 
+        logger.info("Loading configuration file...")
         self.config = confParse.loadSoapyConfig(self.configFile)
-        logger.statusMessage(
-                1, 1,"Loaded configuration file successfully!" )
+        logger.info("Loading configuration file... success!")
 
     def setLoggingLevel(self, level):
         """

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -987,7 +987,7 @@ class Sim(object):
                         sci, self.sciCams[sci].instStrehl,
                         self.sciCams[sci].longExpStrehl)
 
-        logger.statusMessage(iter+1, self.config.sim.nIters, string )
+        logger.statusMessage(iter, self.config.sim.nIters, string )
 
 
     def addToGuiQueue(self):

--- a/soapy/wfs/base.py
+++ b/soapy/wfs/base.py
@@ -68,7 +68,8 @@ Adding new WFSs
 New WFS classes should inherit the ``WFS`` class, then create methods which deal with creating the focal plane and making a measurement from it. To make use of the base-classes ``frame`` method, which will run the WFS entirely, the new class must contain the following methods::
 
     calcFocalPlane(self)
-    makeDetectorPlane(self)
+    integrateDetectorPlane(self)
+    readDetectorPlane(self)
     calculateSlopes(self)
 
 The Final ``calculateSlopes`` method must set ``self.slopes`` to be the measurements made by the WFS. If LGS elongation is to be used for the new WFS, create a ``detectorPlane``, which is added to for each LGS elongation propagation. Have a look at the code for the ``Shack-Hartmann`` and experimental ``Pyramid`` WFSs to get some ideas on how to do this.
@@ -432,8 +433,9 @@ class WFS(object):
                 
             self.calcFocalPlane()
 
-        self.makeDetectorPlane(read=read)
+        self.integrateDetectorPlane()
         if read:
+            self.readDetectorPlane()
             self.calculateSlopes()
             self.zeroData(detector=False)
 
@@ -478,7 +480,10 @@ class WFS(object):
     def calcFocalPlane(self, intensity=None):
         pass
 
-    def makeDetectorPlane(self, read=True):
+    def integrateDetectorPlane(self):
+        pass
+
+    def readDetectorPlane(self):
         pass
 
     def LGSUplink(self):

--- a/soapy/wfs/base.py
+++ b/soapy/wfs/base.py
@@ -432,8 +432,8 @@ class WFS(object):
                 
             self.calcFocalPlane()
 
+        self.makeDetectorPlane(read=read)
         if read:
-            self.makeDetectorPlane()
             self.calculateSlopes()
             self.zeroData(detector=False)
 
@@ -475,7 +475,7 @@ class WFS(object):
     def calcFocalPlane(self, intensity=None):
         pass
 
-    def makeDetectorPlane(self):
+    def makeDetectorPlane(self, read=True):
         pass
 
     def LGSUplink(self):

--- a/soapy/wfs/base.py
+++ b/soapy/wfs/base.py
@@ -450,7 +450,10 @@ class WFS(object):
         if numpy.any(numpy.isnan(self.slopes)):
             numpy.nan_to_num(self.slopes)
 
-        return self.slopes
+        if read:
+            return self.slopes
+        else:
+            return numpy.zeros((self.n_measurements), dtype=float)
 
     def addPhotonNoise(self):
         """

--- a/soapy/wfs/extendedshackhartmann.py
+++ b/soapy/wfs/extendedshackhartmann.py
@@ -79,7 +79,7 @@ class ExtendedSH(shackhartmann.ShackHartmann):
 
         self.corrSubapArrays = numpy.zeros(self.centSubapArrays.shape, dtype=DTYPE)
 
-    def makeDetectorPlane(self):
+    def integrateDetectorPlane(self):
         """
         If an extended object is supplied, convolve with spots to make
         the detector images
@@ -98,7 +98,7 @@ class ExtendedSH(shackhartmann.ShackHartmann):
             self.FPSubapArrays *= fieldMask
 
         # Finally, run put these arrays onto the simulated detector
-        super(ExtendedSH, self).makeDetectorPlane()
+        super(ExtendedSH, self).integrateDetectorPlane()
 
     def makeCorrelationImgs(self):
         """

--- a/soapy/wfs/gradient.py
+++ b/soapy/wfs/gradient.py
@@ -126,7 +126,7 @@ class Gradient(base.WFS):
             self.subapArrays[i] = self.pupilPhase[x1: x2, y1: y2]
 
 
-    def makeDetectorPlane(self):
+    def integrateDetectorPlane(self):
         '''
         Creates a 'detector' image suitable for plotting
         '''

--- a/soapy/wfs/pyramid.py
+++ b/soapy/wfs/pyramid.py
@@ -152,7 +152,7 @@ class Pyramid(base.WFS):
                                                 pSize:pSize+size,
                                                 pSize:pSize+size]
 
-    def makeDetectorPlane(self):
+    def integrateDetectorPlane(self):
 
         #Bin down to requried pixels
         self.wfsDetectorPlane[:] += interp.binImgs(

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -350,7 +350,7 @@ class ShackHartmann(base.WFS):
         if intensity != 1:
             self.subap_focus_intensity *= intensity
 
-    def makeDetectorPlane(self, read=True):
+    def integrateDetectorPlane(self):
         '''
         Scales and bins intensity data onto the detector with a given number of
         pixels.
@@ -379,19 +379,19 @@ class ShackHartmann(base.WFS):
         numbalib.wfs.place_subaps_on_detector(
                 self.binnedFPSubapArrays, self.detector, self.detector_subap_coords, self.valid_subap_coords)
 
-        if read:
-            # Scale data for correct number of photons
-            self.detector /= self.detector.sum()
-            self.detector *= photons_per_mag(
-                    self.config.GSMag, self.mask, self.phase_scale,
-                    self.config.exposureTime, self.soapy_config.sim.photometric_zp
-                    )# * self.config.throughput
+    def readDetectorPlane(self):
+        # Scale data for correct number of photons
+        self.detector /= self.detector.sum()
+        self.detector *= photons_per_mag(
+                self.config.GSMag, self.mask, self.phase_scale,
+                self.config.exposureTime, self.soapy_config.sim.photometric_zp
+                )# * self.config.throughput
 
-            if self.config.photonNoise:
-                self.addPhotonNoise()
+        if self.config.photonNoise:
+            self.addPhotonNoise()
 
-            if self.config.eReadNoise!=0:
-                self.addReadNoise()
+        if self.config.eReadNoise!=0:
+            self.addReadNoise()
 
     def applyLgsUplink(self):
         """

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -350,7 +350,7 @@ class ShackHartmann(base.WFS):
         if intensity != 1:
             self.subap_focus_intensity *= intensity
 
-    def makeDetectorPlane(self):
+    def makeDetectorPlane(self, read=True):
         '''
         Scales and bins intensity data onto the detector with a given number of
         pixels.
@@ -378,18 +378,20 @@ class ShackHartmann(base.WFS):
 
         numbalib.wfs.place_subaps_on_detector(
                 self.binnedFPSubapArrays, self.detector, self.detector_subap_coords, self.valid_subap_coords)
-        # Scale data for correct number of photons
-        self.detector /= self.detector.sum()
-        self.detector *= photons_per_mag(
-                self.config.GSMag, self.mask, self.phase_scale,
-                self.config.exposureTime, self.soapy_config.sim.photometric_zp
-                )# * self.config.throughput
 
-        if self.config.photonNoise:
-            self.addPhotonNoise()
+        if read:
+            # Scale data for correct number of photons
+            self.detector /= self.detector.sum()
+            self.detector *= photons_per_mag(
+                    self.config.GSMag, self.mask, self.phase_scale,
+                    self.config.exposureTime, self.soapy_config.sim.photometric_zp
+                    )# * self.config.throughput
 
-        if self.config.eReadNoise!=0:
-            self.addReadNoise()
+            if self.config.photonNoise:
+                self.addPhotonNoise()
+
+            if self.config.eReadNoise!=0:
+                self.addReadNoise()
 
     def applyLgsUplink(self):
         """

--- a/soapy/wfs/shackhartmann_legacy.py
+++ b/soapy/wfs/shackhartmann_legacy.py
@@ -310,13 +310,13 @@ class ShackHartmannLegacy(base.WFS):
         # Sub-aps need to be flipped to correct orientation
         self.FPSubapsArrays = self.FPSubapArrays[:, ::-1, ::-1]
 
-    def makeDetectorPlane(self):
+    def integrateDetectorPlane(self):
         '''
         Scales and bins intensity data onto the detector with a given number of
         pixels.
 
         If required, will first convolve final PSF with LGS PSF, then bin
-        PSF down to detector size. Finally puts back into ``wfsFocalPlane``
+        PSF down to detector size. Finally adds back to ``wfsFocalPlane``
         array in correct order.
         '''
 
@@ -388,6 +388,7 @@ class ShackHartmannLegacy(base.WFS):
             self.wfsDetectorPlane[x1:x2, y1:y2] += (
                     self.binnedFPSubapArrays[i, x1_fp:x2_fp, y1_fp:y2_fp])
 
+    def readDetectorPlane(self):
         # Scale data for correct number of photons
         self.wfsDetectorPlane /= self.wfsDetectorPlane.sum()
         self.wfsDetectorPlane *= aotools.photons_per_mag(


### PR DESCRIPTION
This pull request improves the simulation of bandwidth errors as follows:
- The SH sensor now integrates for the duration of the its configured `exposureTime`.
- While integrating, the SH sensor returns zero slopes, i.e. no correction is therefore integrated.

With a combination of `SimConfig.loopTime`, `WfsConfig.exposureTime`, and `SimConfig.loopDelay`, one should be able to properly simulate loop delay, and bandwidth effects. Note that the `SimConfig.loopDelay` should not contain the WFS integration time and the DM zero hold effects.