### PR TITLE
LGS tip-tillt correction

### DIFF
--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -871,6 +871,10 @@ class LgsConfig(ConfigObj):
         ``naProfile``        list: The relative sodium layer
                              strength for each elongation
                              layer. If None, all equal.          ``None``
+        ``correctLgsTT``     bool: correct the LGS tip-tilt on   ``False``
+                                the sensor. Required 'removeTT'
+                                == True and 'uplinkgain>0'
+        ``uplinkgain``       float: LGS tip-tilt gain            0
         ==================== =================================   ===========
 
     """
@@ -888,6 +892,8 @@ class LgsConfig(ConfigObj):
                         ("elongationLayers", 10),
                         ("launchPosition",  numpy.array([0,0])),
                         ("naProfile", None),
+                        ("correctLgsTT", False),
+                        ("uplinkgain", 0)
                         ]
     calculatedParams = ["position"]
 
@@ -908,6 +914,7 @@ class LgsConfig(ConfigObj):
         self.wavelength = float(self.wavelength)
         self.height = float(self.height)
         self.launchPosition = numpy.array(self.launchPosition)
+        self.uplinkgain = float(self.uplinkgain)
 
 class DmConfig(ConfigObj):
     """

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -907,6 +907,7 @@ class LgsConfig(ConfigObj):
 
         self.wavelength = float(self.wavelength)
         self.height = float(self.height)
+        self.launchPosition = numpy.array(self.launchPosition)
 
 class DmConfig(ConfigObj):
     """

--- a/soapy/wfs/base.py
+++ b/soapy/wfs/base.py
@@ -161,6 +161,17 @@ class WFS(object):
         self.calcTiltCorrect()
         self.getStatic()
 
+        # Set up array for tip-tilt uplink compensation
+        self._upTTCommand = numpy.array([0, 0])
+
+        self._nx_elements = int(round(self.pupil_size))
+        coords = numpy.linspace(
+                    -1, 1, self._nx_elements)
+        self.tip1arcsec, self.tilt1arcsec = numpy.meshgrid(coords, coords)
+        tt_amp = -(ASEC2RAD * self.soapy_config.tel.telDiam/2.) * 1e9
+        self.tip1arcsec *= tt_amp
+        self.tilt1arcsec *= tt_amp
+
 ############################################################
 # Initialisation routines
 
@@ -429,7 +440,7 @@ class WFS(object):
             self.uncorrectedPhase = self.los.phase.copy()/self.los.phs2Rad
             if phase_correction is not None:
                 self.los.performCorrection(phase_correction)
-                
+
             self.calcFocalPlane()
 
         if read:
@@ -480,6 +491,12 @@ class WFS(object):
 
     def LGSUplink(self):
         pass
+
+    def correctUplinkTilt(self, phase):
+        self._upTTCommand += self.config.uplinkgain * self._tiptilt
+
+        phase -= self._upTTCommand[0] * self.tip1arcsec
+        phase -= self._upTTCommand[1] * self.tilt1arcsec
 
     def calculateSlopes(self):
         self.slopes = self.los.EField

--- a/soapy/wfs/base.py
+++ b/soapy/wfs/base.py
@@ -83,7 +83,7 @@ import numpy.random
 
 import aotools
 
-from .. import AOFFT, LGS, logger, lineofsight_legacy
+from .. import AOFFT, LGS, logger, lineofsight_legacy, interp
 
 # xrange now just "range" in python3.
 # Following code means fastest implementation used in 2 and 3
@@ -287,7 +287,7 @@ class WFS(object):
         h = self.elongHeights[elongLayer]
         dh = h - self.config.GSHeight
         H = float(self.lgsConfig.height)
-        d = numpy.array(self.lgsLaunchPos).astype('float32') * self.los.telDiam/2.
+        d = numpy.array(self.lgsLaunchPos).astype('float32') * self.los.telescope_diameter/2.
         D = self.telescope_diameter
         theta = (d.astype("float")/H) - self.config.GSPosition
 

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -199,9 +199,9 @@ class ShackHartmann(base.WFS):
                     (self.n_subaps, self.subapFFTPadding, self.subapFFTPadding), dtype=CDTYPE)
             self.iFFT = pyfftw.FFTW(
                 self.ifft_input_data, self.ifft_output_data, axes=(-2, -1),
-                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT"),
-                direction="FFTW_BACKWARD"
-                )
+                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT")) #,
+                # direction="FFTW_BACKWARD"
+                # )
 
             self.lgs_ifft_input_data = pyfftw.empty_aligned(
                 (self.subapFFTPadding, self.subapFFTPadding), dtype=CDTYPE)
@@ -209,9 +209,9 @@ class ShackHartmann(base.WFS):
                 (self.subapFFTPadding, self.subapFFTPadding), dtype=CDTYPE)
             self.lgs_iFFT = pyfftw.FFTW(
                 self.lgs_ifft_input_data, self.lgs_ifft_output_data, axes=(0, 1),
-                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT"),
-                direction="FFTW_BACKWARD"
-                )
+                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT")) #,
+                # direction="FFTW_BACKWARD"
+                # )
 
     def initLGS(self):
         super(ShackHartmann, self).initLGS()

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -74,7 +74,7 @@ class ShackHartmann(base.WFS):
             self.SUBAP_OVERSIZE = 1
         else:
             self.SUBAP_OVERSIZE = 2
-        
+
         self.nx_detector_pixels = self.nx_subaps * (self.nx_subap_pixels + self.nx_guard_pixels) + self.nx_guard_pixels
 
         self.nx_subap_interp *= self.SUBAP_OVERSIZE
@@ -442,8 +442,13 @@ class ShackHartmann(base.WFS):
         self.slopes[:] = slopes.reshape(self.n_subaps * 2)
 
         if self.config.removeTT == True:
-            self.slopes[:self.n_subaps] -= self.slopes[:self.n_subaps].mean()
-            self.slopes[self.n_subaps:] -= self.slopes[self.n_subaps:].mean()
+            _tip = self.slopes[:self.n_subaps].mean()
+            _tilt = self.slopes[self.n_subaps:].mean()
+            self._tiptilt = numpy.array([_tip, _tilt])
+            self.slopes[:self.n_subaps] -= self._tiptilt[0]
+            # self.slopes[:self.n_subaps].mean()
+            self.slopes[self.n_subaps:] -= self._tiptilt[1]
+            # self.slopes[self.n_subaps:].mean()
 
         if self.config.angleEquivNoise and not self.iMat:
             pxlEquivNoise = (

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -199,9 +199,8 @@ class ShackHartmann(base.WFS):
                     (self.n_subaps, self.subapFFTPadding, self.subapFFTPadding), dtype=CDTYPE)
             self.iFFT = pyfftw.FFTW(
                 self.ifft_input_data, self.ifft_output_data, axes=(-2, -1),
-                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT")) #,
-                # direction="FFTW_BACKWARD"
-                # )
+                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT"),
+                direction="FFTW_BACKWARD")
 
             self.lgs_ifft_input_data = pyfftw.empty_aligned(
                 (self.subapFFTPadding, self.subapFFTPadding), dtype=CDTYPE)
@@ -209,9 +208,8 @@ class ShackHartmann(base.WFS):
                 (self.subapFFTPadding, self.subapFFTPadding), dtype=CDTYPE)
             self.lgs_iFFT = pyfftw.FFTW(
                 self.lgs_ifft_input_data, self.lgs_ifft_output_data, axes=(0, 1),
-                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT")) #,
-                # direction="FFTW_BACKWARD"
-                # )
+                threads=self.threads, flags=(self.config.fftwFlag, "FFTW_DESTROY_INPUT"),
+                direction="FFTW_BACKWARD")
 
     def initLGS(self):
         super(ShackHartmann, self).initLGS()

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -444,11 +444,11 @@ class ShackHartmann(base.WFS):
         if self.config.removeTT == True:
             _tip = self.slopes[:self.n_subaps].mean()
             _tilt = self.slopes[self.n_subaps:].mean()
-            self._tiptilt = numpy.array([_tip, _tilt])
-            self.slopes[:self.n_subaps] -= self._tiptilt[0]
+            self.slopes[:self.n_subaps] -= _tip
             # self.slopes[:self.n_subaps].mean()
-            self.slopes[self.n_subaps:] -= self._tiptilt[1]
+            self.slopes[self.n_subaps:] -= _tilt
             # self.slopes[self.n_subaps:].mean()
+            self._tiptilt = numpy.array([_tip, _tilt]) * self.pixel_scale
 
         if self.config.angleEquivNoise and not self.iMat:
             pxlEquivNoise = (

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -399,7 +399,7 @@ class ShackHartmann(base.WFS):
 
         self.lgs.getLgsPsf(self.los.scrns)
 
-        self.lgs_ifft_input_data[:] = self.lgs.psf[::-1, ::-1]
+        self.lgs_ifft_input_data[:] = self.lgs.psf  #self.lgs.psf[::-1, ::-1]
         self.lgs_iFFT()
 
         self.ifft_input_data[:] = self.subap_focus_intensity


### PR DESCRIPTION
This PR concerns the following:
- Fix typos concerning LGS spot elongation
- LGS image should not be flipped (line 400-402 in base.py). Can be seen in correlation map, e.g. for an on-axis launch the central slope variance should be minimum (if no obscuration, central slopes should be close to 0 for similar launch aperture and subaperture).
- WIP: Correction of LGS tip-tilt is now possible using a combination of `removeTT=True`, `correctLgsTT`. At the moment this may not be fully realistic but helps to stabilize the LGS on a Shack-Hartmann. Comments are welcome.


