### PR TITLE
Moved photometric_zp

### DIFF
--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -552,7 +552,6 @@ class SimConfig(ConfigObj):
                             ("simOversize", 1.02),
                             ("loopDelay", 0),
                             ("threads", 1),
-                            ("photometric_zp", 2e9),
                         ]
 
     # Parameters which may be set at some point and are allowed

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -448,7 +448,7 @@ class ConfigObj(object):
 
 class SimConfig(ConfigObj):
     """
-    Configuration parameters relavent for the entire simulation. These should be held at the beginning of the parameter file with no indendation.
+    Configuration parameters relevant for the entire simulation. These should be held at the beginning of the parameter file with no indendation.
 
     Required:
         =============   ===================
@@ -494,9 +494,6 @@ class SimConfig(ConfigObj):
                             of ``loopTime``                     ``0``
         ``threads``         int: Number of threads to use
                             for multithreaded operations        ``1``
-        ``photometric_zp``  float: Photometric zeropoint -
-                            number of photons/meter/second
-                            from a magnitude 0 star             ``2e9``
         ==================  =================================   ===============
 
     Data Saving (all default to False):
@@ -745,6 +742,9 @@ class WfsConfig(ConfigObj):
         ``nx_guard_pixels``     int: Guard Pixels between
                                 Shack-Hartmann sub-apertures
                                 (Not currently operational)         ``0``
+        ``photometric_zp``      float: Photometric zeropoint -
+                                number of photons/meter^2/second/band
+                                from a magnitude 0 star             ``2e9``
         =====================   ================================== ===========
 
 
@@ -780,6 +780,7 @@ class WfsConfig(ConfigObj):
                         ("subapFOV", 5),
                         ("correlationFFTPad", None),
                         ("nx_guard_pixels", 0),
+                        ("photometric_zp", 2e9)
                         ]
 
         # Parameters which may be Set at some point and are allowed

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -2,10 +2,10 @@
 Shack-Hartmann WFS
 
 The Shack-Hartmann WFS is simulated using the `ShackHartmann` class contained here.
-Pupil phase or complex amplitude is recieved from the line of sight on the WFS, via the base WFS class.
-This array of phase or complex amplitude is chopped into relavent sub-apertures.
+Pupil phase or complex amplitude is received from the line of sight on the WFS, via the base WFS class.
+This array of phase or complex amplitude is chopped into relevant sub-apertures.
 Before this however, it is interpolated such that the correct sub-aperture field of view will be
- obtianed. This also means that the phase does not need to be a integer multiple of the number
+ obtained. This also means that the phase does not need to be a integer multiple of the number
  of sub-apertures. An FFT is performed to create the focal plane image for each sub-aperture.
  To obtain a multiple of the number of pixels per sub-aperture, the FFT is padded to an appropriate size.
  To get the final detector frame the focal plane is binned, photon flux is calculated and noise added.
@@ -384,7 +384,7 @@ class ShackHartmann(base.WFS):
         self.detector /= self.detector.sum()
         self.detector *= photons_per_mag(
                 self.config.GSMag, self.mask, self.phase_scale,
-                self.config.exposureTime, self.soapy_config.sim.photometric_zp
+                self.config.exposureTime, self.config.photometric_zp
                 )# * self.config.throughput
 
         if self.config.photonNoise:
@@ -570,7 +570,7 @@ def photons_per_mag(mag, mask, phase_scale, exposureTime, zeropoint):
         mask (ndarray): 2-d pupil mask. 1 if aperture clear, 0 if not
         phase_scale (float): Size of pupil mask pixel in metres
         exposureTime (float): WFS exposure time in seconds
-        zeropoint (float): Photometric zeropoint of mag 0 star in photons/metre^2/seconds
+        zeropoint (float): Photometric zeropoint of mag 0 star in photons/metre^2/second/band
 
     Returns:
         float: photons per WFS frame

--- a/soapy/wfs/shackhartmann_legacy.py
+++ b/soapy/wfs/shackhartmann_legacy.py
@@ -1,5 +1,5 @@
 """
-A Legacy Shack Hartmann WFS simulation that shoudl nto normally be used as it is quite slow,
+A Legacy Shack Hartmann WFS simulation that should not normally be used as it is quite slow,
 but it required for some features such as LGS spot elongation
 """
 


### PR DESCRIPTION
Moved the parameter "photometric_zp" from sim parameters to WFS parameters. The user can now independently set amount of photons to each WFS.

I have also corrected a couple of spelling errors in the documentation.