### PR TITLE
Fix for LGS uplink with ShackHartmann wfs

### DIFF
--- a/conf/sh_8x8_lgs-uplink.yaml
+++ b/conf/sh_8x8_lgs-uplink.yaml
@@ -43,7 +43,7 @@ WFS:
     wavelength: 600e-9
 
   1:
-    type: ShackHartmannLegacy
+    type: ShackHartmann
     GSPosition: [0, 0]
     GSHeight: 90000
     GSMag: 8

--- a/soapy/wfs/shackhartmann.py
+++ b/soapy/wfs/shackhartmann.py
@@ -401,7 +401,7 @@ class ShackHartmann(wfs.WFS):
 
         self.lgs.getLgsPsf(self.los.scrns)
 
-        self.lgs_ifft_input_data[:] = self.lgs.psf[::-1, ::-1]
+        self.lgs_ifft_input_data[:] = self.lgs.psf
         self.lgs_iFFT()
 
         self.ifft_input_data[:] = self.subap_focus_intensity
@@ -413,7 +413,7 @@ class ShackHartmann(wfs.WFS):
         # back to Focal Plane.
         self.fft_input_data[:] = self.ifft_output_data
         self.FFT()
-        self.subap_focus_intensity[:] = AOFFT.ftShift2d(self.fft_output_data).real
+        self.subap_focus_intensity[:] = AOFFT.ftShift2d(self.fft_output_data).real[:,::-1,::-1]
 
     def calculateSlopes(self):
         '''


### PR DESCRIPTION
Fix for LGS uplink with using `ShackHartmann` wfs class. This fixes the backwards slopes issue when `uplink=True`, so the non-legacy version can be used. Also changed the example config file to use `ShackHartmann` instead of `ShackHartmannLegacy`.

I note that one of the changes (not flipping LGS psf) was also implemented in #98  

