### PR TITLE
minor LGS developments

### DIFF
--- a/conf/sh_8x8_lgs-uplink-precomp.yaml
+++ b/conf/sh_8x8_lgs-uplink-precomp.yaml
@@ -1,0 +1,100 @@
+# Example configuration file for AO system with single, on-axis LGS.
+# LGS features realistic uplink propagation, so a NGS TT sensor also present
+# LGS launched from primary 1m telescope aperture ("monostatic" configuration), 
+# the size of the launched beam requires the LGS to be 1) focused at 90km and 2) 
+# precompensated by applying DM correction before launch. However, a much tighter 
+# (and therefore brighter) LGS spot results. 
+
+simName: sh_8x8_lgsUp_precomp
+pupilSize: 128
+nGS: 2
+nDM: 2
+nSci: 1
+nIters: 5000
+loopTime: 0.0025
+
+verbosity: 2
+
+saveCMat: False
+saveSlopes: True
+saveDmCommands: False
+saveLgsPsf: True
+saveSciPsf: True
+
+Atmosphere:
+  scrnNo:  4
+  scrnHeights: [0,5000,10000,15000]
+  scrnStrengths: [0.5,0.3,0.1,0.1]
+  windDirs: [0,45,90,135]
+  windSpeeds: [10,10,15,20]
+  wholeScrnSize: 2048
+  r0: 0.15
+
+Telescope:
+  telDiam: 1
+  obsDiam: 0.35
+  mask: circle
+
+WFS:
+  0:
+    type: ShackHartmann
+    GSPosition: [0,0]
+    nxSubaps: 2
+    pxlsPerSubap: 10
+    subapFOV: 5.0
+    wavelength: 600e-9
+
+
+  1:
+    type: ShackHartmann
+    GSPosition: [0, 0]
+    GSHeight: 90000
+    GSMag: 8
+    nxSubaps: 10
+    pxlsPerSubap: 10
+    subapFOV: 6.0
+    wavelength: 589e-9
+    removeTT: True
+    centThreshold: 0.3
+    fftOversamp: 6
+    propagationMode: Physical
+
+    lgs:
+      propagationMode: Physical
+      uplink: True
+      pupilDiam: 1.0
+      obsDiam: 0.35
+      wavelength: 589e-9
+      height:   90e3
+      precompensated: True 
+
+DM:
+  0: 
+    type: TT
+    nxActuators: 2
+    svdConditioning: 0.
+    gain: 0.6
+    iMatValue: 0.25
+    wfs: 0
+
+  1:
+    type: Piezo
+    nxActuators: 11
+    svdConditioning: 0.05
+    gain: 0.6
+    iMatValue: 500
+    wfs: 1
+
+
+Reconstructor:
+  type: MVM_SeparateDMs
+  svdConditioning: 0.03
+  gain: 0.6
+
+Science:
+  0:
+    type: PSF
+    position: [0,0]
+    FOV: 4.0
+    wavelength: 600e-9
+    pxls: 120

--- a/soapy/LGS.py
+++ b/soapy/LGS.py
@@ -227,7 +227,6 @@ class LGS_Physical(LGS):
         # Get the angular scale in radians of the output array
         self.outPxlScale_rad = self.outPxlScale_m/self.config.height
 
-
         # The number of pixels required across the LGS image
         if self.nOutPxls is None:
             self.nOutPxls = self.simConfig.simSize
@@ -250,8 +249,12 @@ class LGS_Physical(LGS):
         # this is the geometric focus assuming you want to focus at the LGS height
         focus_rms = self.config.height / ( 2.*numpy.sqrt(3.) * 8. * (self.config.height/self.config.pupilDiam)**2 ) * (2*numpy.pi)/self.config.wavelength
 
-        focus = -focus_rms * aotools.zernike_noll(4, self.lgsPupilPxls)
-        focus = numpy.pad(focus, (self.mask.shape[-1]-self.lgsPupilPxls)//2)
+        focus = numpy.zeros(self.mask.shape, dtype=complex)
+        start = self.mask.shape[-1]//2 - self.lgsPupilPxls//2
+        end = self.mask.shape[-1]//2 + self.lgsPupilPxls//2
+        if self.lgsPupilPxls % 2 != 0:
+            end += 1
+        focus[start:end,start:end] = -focus_rms * aotools.zernike_noll(4, self.lgsPupilPxls)
 
         # NOTE applying focus here makes mask complex, doesn't seem to break anything
         self.mask = self.mask.astype(complex) * numpy.exp(1j * focus)

--- a/soapy/LGS.py
+++ b/soapy/LGS.py
@@ -67,6 +67,9 @@ class LGS(object):
         self.config.position = self.wfsConfig.GSPosition
         self.losMask = None
 
+        # correction phase for LGS precompensation
+        self.precorrection = None            
+
         self.calcInitParams()
 
         self.initLos()
@@ -111,7 +114,7 @@ class LGS(object):
 
     def getLgsPsf(self, scrns):
         logger.debug("Get LGS PSF")
-        self.los.frame(scrns)
+        self.los.frame(scrns, self.precorrection)
         self.EField = self.los.EField
         self.phase = self.los.phase
 
@@ -159,6 +162,9 @@ class LGS_Geometric(LGS):
 
         # The mask to apply before geometric FFTing
         self.mask = aotools.circle(self.nFovPxls/2., self.nFovPxls)
+        if self.config.obsDiam > 0:
+            obspxls = self.nFovPxls * (self.config.obsDiam/self.config.pupilDiam)
+            self.mask -= aotools.circle(obspxls/2, self.nFovPxls)
 
         self.losNOutPxls = self.lgsPupilPxls
         self.losOutPxlScale = self.config.pupilDiam/self.lgsPupilPxls
@@ -237,6 +243,19 @@ class LGS_Physical(LGS):
         # The mask to apply before physical propagation
         self.lgsPupilPxls = int(round(self.config.pupilDiam/self.outPxlScale_m))
         self.mask = aotools.circle(self.lgsPupilPxls/2., 3*self.nOutPxls)
+        if self.config.obsDiam > 0:
+            obspxls = self.config.obsDiam/self.outPxlScale_m
+            self.mask -= aotools.circle(obspxls/2., self.mask.shape[-1])
+
+        # this is the geometric focus assuming you want to focus at the LGS height
+        focus_rms = self.config.height / ( 2.*numpy.sqrt(3.) * 8. * (self.config.height/self.config.pupilDiam)**2 ) * (2*numpy.pi)/self.config.wavelength
+
+        focus = -focus_rms * aotools.zernike_noll(4, self.lgsPupilPxls)
+        focus = numpy.pad(focus, (self.mask.shape[-1]-self.lgsPupilPxls)//2)
+
+        # NOTE applying focus here makes mask complex, doesn't seem to break anything
+        self.mask = self.mask.astype(complex) * numpy.exp(1j * focus)
+
         self.losMask = self.mask
 
         self.losOutPxlScale = self.outPxlScale_m

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -885,6 +885,8 @@ class LgsConfig(ConfigObj):
         ``uplink``           bool: Include LGS uplink effects    ``False``
         ``pupilDiam``        float: Diameter of LGS launch
                              aperture in metres.                 ``0.3``
+        ``obsDiam``          float: Diameter of LGS launch       ``0``
+                             central obscuration in metres
         ``wavelength``       float: Wavelength of laser beam
                              in metres                           ``600e-9``
         ``propagationMode``  str: Mode of light propogation
@@ -911,6 +913,8 @@ class LgsConfig(ConfigObj):
         ``naProfile``        list: The relative sodium layer
                              strength for each elongation
                              layer. If None, all equal.          ``None``
+        ``precompensated``   bool: precompensate LGS with DM(s)  ``False``
+                             before launching
         ==================== =================================   ===========
 
     """
@@ -919,6 +923,7 @@ class LgsConfig(ConfigObj):
 
     optionalParams = [  ("uplink", False),
                         ("pupilDiam", 0.3),
+                        ("obsDiam", 0.0),
                         ("wavelength", 600e-9),
                         ("propagationMode", "Physical"),
                         ("height", 90000),
@@ -928,6 +933,7 @@ class LgsConfig(ConfigObj):
                         ("elongationLayers", 10),
                         ("launchPosition",  numpy.array([0,0])),
                         ("naProfile", None),
+                        ("precompensated", False),
                         ]
     calculatedParams = ["position"]
 

--- a/soapy/lineofsight.py
+++ b/soapy/lineofsight.py
@@ -313,10 +313,11 @@ class LineOfSight(object):
             apos (ndarray, optional):  The angular position of the GS in radians. If not set, will use the config position
         '''
 
-        self.EField[:] *= physical_atmosphere_propagation(
+        self.EField[:] = physical_atmosphere_propagation(
             self.phase_screens, self.outMask, self.layer_altitudes, self.source_altitude,
             self.wavelength, self.out_pixel_scale,
-            propagation_direction=self.propagation_direction)
+            propagation_direction=self.propagation_direction,
+            input_efield=self.EField)
 
         return self.EField
 
@@ -411,6 +412,7 @@ def physical_atmosphere_propagation(
 
     phs2Rad = 2 * numpy.pi / (wavelength * 10 ** 9)
 
+    EFieldBuf = input_efield
     if input_efield is None:
         EFieldBuf = numpy.exp(
                 1j*numpy.zeros((nx_output_pixels,) * 2)).astype(CDTYPE)

--- a/soapy/wfs/wfs.py
+++ b/soapy/wfs/wfs.py
@@ -435,6 +435,9 @@ class WFS(object):
             if phase_correction is not None:
                 self.los.performCorrection(phase_correction)
                 
+                if self.config.lgs and self.config.lgs.precompensated:
+                    self.lgs.precorrection = phase_correction
+
             self.calcFocalPlane()
 
         self.integrateDetectorPlane()


### PR DESCRIPTION
Two new config parameters added to the LGS object: 

`obsDiam`, allows LGS to be launched from an aperture with a central obscuration. This is mainly only relevant for larger launch apertures. I've also added a focus term that is applied to the LGS which is required for larger apertures.

`precompensated`, the DM phase is applied to the LGS before launch
