### PR TITLE
Bugfix: incorrect conditioning applied to MVM for scipy>1.6

### DIFF
--- a/soapy/reconstruction.py
+++ b/soapy/reconstruction.py
@@ -20,7 +20,6 @@ import traceback
 import time
 
 import numpy
-import scipy
 
 from . import logger
 
@@ -449,7 +448,7 @@ class MVM(Reconstructor):
 
         logger.info("Invert iMat with conditioning: {:.4f}".format(
                 self.config.svdConditioning))
-        self.control_matrix = scipy.linalg.pinv(
+        self.control_matrix = numpy.linalg.pinv(
                 self.interaction_matrix, self.config.svdConditioning
                 )
 


### PR DESCRIPTION
The MVM reconstructor class erroneously uses `scipy.linalg.pinv` instead of `numpy.linalg.pinv`. This was fine until scipy 1.7 where the `pinv` arguments were changed. This means you get different conditioning applied to the MVM interaction matrix inversion depending on your version of scipy and can break simulations depending on the choice of `svdConditioning` parameter.

Changed to use the numpy version of the function, which is consistent with other reconstructors, and removed scipy import.