### PR TITLE
remove obsolete windows interrupt fix

### DIFF
--- a/bin/soapy
+++ b/bin/soapy
@@ -8,32 +8,6 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 
-if sys.platform == "win32":
-    # hack to stop the interpretter craching on ctrl-c events when scipy imported.
-    # described in more detail here:
-    # http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
-
-    import imp
-    import ctypes
-    import _thread as thread
-    import win32api
-
-    # Load the DLL manually to ensure its handler gets
-    # set before our handler.
-    basepath = os.path.dirname(sys.executable)
-    ctypes.CDLL(os.path.join(basepath, "Library", "bin", 'libmmd.dll'))
-    ctypes.CDLL(os.path.join(basepath, "Library", "bin", 'libifcoremd.dll'))
-
-    # Now set our handler for CTRL_C_EVENT. Other control event
-    # types will chain to the next handler.
-    def handler(dwCtrlType, hook_sigint=thread.interrupt_main):
-        if dwCtrlType == 0: # CTRL_C_EVENT
-            hook_sigint()
-            return 1 # don't chain to the next handler
-        return 0 # chain to the next handler
-
-    win32api.SetConsoleCtrlHandler(handler, 1)
-
 from argparse import ArgumentParser
 import IPython
 import soapy

--- a/soapy/__init__.py
+++ b/soapy/__init__.py
@@ -20,30 +20,6 @@
 
 import os
 import sys
-if sys.platform == "win32":
-    # hack to stop the interpretter craching on ctrl-c events when scipy imported.
-    # described in more detail here:
-    # http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
-
-    import ctypes
-    import _thread as thread
-    import win32api
-
-    # Load the DLL manually to ensure its handler gets
-    # set before our handler.
-    basepath = os.path.dirname(sys.executable)
-    ctypes.CDLL(os.path.join(basepath, "Library", "bin", 'libmmd.dll'))
-    ctypes.CDLL(os.path.join(basepath, "Library", "bin", 'libifcoremd.dll'))
-
-    # Now set our handler for CTRL_C_EVENT. Other control event
-    # types will chain to the next handler.
-    def handler(dwCtrlType, hook_sigint=thread.interrupt_main):
-        if dwCtrlType == 0: # CTRL_C_EVENT
-            hook_sigint()
-            return 1 # don't chain to the next handler
-        return 0 # chain to the next handler
-
-    win32api.SetConsoleCtrlHandler(handler, 1)
 
 # Useful things to have in top namespace
 from .simulation import Sim, make_mask


### PR DESCRIPTION
The old fix for scipy isn't needed anymore (at least I haven't experienced any issues) but it does cause issues in some virtual environments as the dll files are not necessarily where these scripts say they are.